### PR TITLE
Removed reference to highlightJs.css.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ protected override void OnInit()
 2. In your `_Host.cshtml` file add this code to have `moment.js` with the locales:
 
 ```html
-link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/styles/default.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"
         integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo="
         crossorigin="anonymous">
@@ -117,7 +116,6 @@ link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/
 or this code if you want the bundled version of `Chart.Js`, but without the locales of `moment.js` (`moment.js` itself is then included in the bundle):
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.8/styles/default.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script> <!--Contains moment.js for time axis-->
 <script src="~/ChartJs.Blazor/ChartJsInterop.js" type="text/javascript" language="javascript"></script>
 ```

--- a/WebCore/Pages/_Host.cshtml
+++ b/WebCore/Pages/_Host.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/"
+@page "/"
 @namespace WebCore.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *,ChartJs.Blazor
@@ -27,7 +27,6 @@
 
     <script src="_framework/blazor.server.js"></script>
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"
             integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo="
             crossorigin="anonymous">


### PR DESCRIPTION
As discussed under https://github.com/Joelius300/ChartJSBlazor/pull/19.