### PR TITLE
Indexable options

### DIFF
--- a/ChartJs.Blazor/ChartJS/Common/IndexableOption.cs
+++ b/ChartJs.Blazor/ChartJS/Common/IndexableOption.cs
@@ -5,16 +5,16 @@ using System.Text;
 namespace ChartJs.Blazor.ChartJS.Common
 {
     /// <summary>
-    /// Represents a field that can be either a single value or multiple values (array). This is used for typesafe js-interop.
+    /// Represents an object that can be either a single value or an array of values. This is used for typesafe js-interop.
     /// </summary>
     /// <typeparam name="T">The type of data this <see cref="IndexableOption{T}"/> is supposed to hold.</typeparam>
     [Newtonsoft.Json.JsonConverter(typeof(IndexableOptionConverter))]   // newtonsoft for now
-    public sealed class IndexableOption<T>
+    public struct IndexableOption<T> : IEquatable<IndexableOption<T>>
     {
         /// <summary>
-        /// The compile-time name of the property which stores the wrapped value.
+        /// The compile-time name of the property which stores the wrapped value. This is used internally for serialization.
         /// </summary>
-        public const string PropertyName = nameof(Value);
+        internal const string PropertyName = nameof(Value);
 
         /// <summary>
         /// The actual value represented by this instance.
@@ -23,34 +23,28 @@ namespace ChartJs.Blazor.ChartJS.Common
 
         /// <summary>
         /// Gets the value indicating whether the option wrapped in this <see cref="IndexableOption{T}"/> is indexed. 
-        /// If true, the wrapped value represents an array of <typeparamref name="T"/>, if not, a single value of <typeparamref name="T"/>.
+        /// <para>True if the wrapped value represents an array of <typeparamref name="T"/>, false if it represents a single value of <typeparamref name="T"/>.</para>
         /// </summary>
         public bool IsIndexed { get; }
 
         /// <summary>
         /// Creates a new instance of <see cref="IndexableOption{T}"/> which represents a single value.
         /// </summary>
-        /// <param name="singleValue">The single value this <see cref="IndexableOption{T}"/> represents.</param>
+        /// <param name="singleValue">The single value this <see cref="IndexableOption{T}"/> should represent.</param>
         public IndexableOption(T singleValue)
         {
-            if (singleValue == null)
-                throw new ArgumentNullException(nameof(singleValue));
-
+            Value = singleValue ?? throw new ArgumentNullException(nameof(singleValue));
             IsIndexed = false;
-            Value = singleValue;
         }
 
         /// <summary>
         /// Creates a new instance of <see cref="IndexableOption{T}"/> which represents an array of values.
         /// </summary>
-        /// <param name="indexedValues">The array of values this <see cref="IndexableOption{T}"/> represents.</param>
+        /// <param name="indexedValues">The array of values this <see cref="IndexableOption{T}"/> should represent.</param>
         public IndexableOption(T[] indexedValues)
         {
-            if (indexedValues == null)
-                throw new ArgumentNullException(nameof(indexedValues));
-
+            Value = indexedValues ?? throw new ArgumentNullException(nameof(indexedValues));
             IsIndexed = true;
-            Value = indexedValues;
         }
 
         /// <summary>
@@ -65,9 +59,49 @@ namespace ChartJs.Blazor.ChartJS.Common
         /// <param name="indexedValues">The array of values to wrap</param>
         public static implicit operator IndexableOption<T>(T[] indexedValues) => new IndexableOption<T>(indexedValues);
 
-        public static implicit operator IndexableOption<T>(List<string> v)
+        /// <summary>
+        /// Explicitly unwraps an <see cref="IndexableOption{T}"/> to a single value.
+        /// <para>If this instance represents an array of values instead of a single value, an <see cref="InvalidCastException"/> will be thrown.</para>
+        /// </summary>
+        /// <param name="wrappedValue">The wrapped single value</param>
+        public static explicit operator T(IndexableOption<T> wrappedValue)
         {
-            throw new NotImplementedException();
+            if (wrappedValue.IsIndexed)
+                throw new InvalidCastException("This instance represents an array of values and can't be converted to a single value.");
+
+            return (T)wrappedValue.Value;
+        }
+
+        /// <summary>
+        /// Explicitly unwraps an <see cref="IndexableOption{T}"/> to an array of values.
+        /// <para>If this instance represents a single value instead of an array of values, an <see cref="InvalidCastException"/> will be thrown.</para>
+        /// </summary>
+        /// <param name="wrappedValue">The wrapped array of values</param>
+        public static explicit operator T[](IndexableOption<T> wrappedValue)
+        {
+            if (!wrappedValue.IsIndexed)
+                throw new InvalidCastException("This instance represents a single value and can't be converted to an array of values.");
+
+            return (T[])wrappedValue.Value;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="IndexableOption{T}"/> instance is considered equal to the current instance.
+        /// </summary>
+        /// <param name="other">The <see cref="IndexableOption{T}"/> to compare with.</param>
+        /// <returns>true if the objects are considered equal; otherwise, false.</returns>
+        public bool Equals(IndexableOption<T> other)
+        {
+            if (IsIndexed != other.IsIndexed) return false;
+
+            if (IsIndexed)
+            {
+                return EqualityComparer<T[]>.Default.Equals((T[])Value, (T[])other.Value);
+            }
+            else
+            {
+                return EqualityComparer<T>.Default.Equals((T)Value, (T)other.Value);
+            }
         }
 
         /// <summary>
@@ -77,13 +111,15 @@ namespace ChartJs.Blazor.ChartJS.Common
         /// <returns>true if the objects are considered equal; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
+            if (obj == null) return false;
+
             if (obj is IndexableOption<T> option)
             {
-                return EqualityComparer<object>.Default.Equals(Value, option.Value);
+                return Equals(option);
             }
             else
             {
-                return EqualityComparer<object>.Default.Equals(Value, obj);
+                return Value.Equals(obj);
             }
         }
 
@@ -93,7 +129,7 @@ namespace ChartJs.Blazor.ChartJS.Common
         /// <returns>The hash of the underlying object.</returns>
         public override int GetHashCode()
         {
-            return -1937169414 + EqualityComparer<object>.Default.GetHashCode(Value);
+            return -1937169414 + Value.GetHashCode();
         }
     }
 }

--- a/ChartJs.Blazor/ChartJS/Common/IndexableOption.cs
+++ b/ChartJs.Blazor/ChartJS/Common/IndexableOption.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ChartJs.Blazor.ChartJS.Common
+{
+    /// <summary>
+    /// Represents a field that can be either a single value or multiple values (array). This is used for typesafe js-interop.
+    /// </summary>
+    /// <typeparam name="T">The type of data this <see cref="IndexableOption{T}"/> is supposed to hold.</typeparam>
+    [Newtonsoft.Json.JsonConverter(typeof(IndexableOptionConverter))]   // newtonsoft for now
+    public sealed class IndexableOption<T>
+    {
+        /// <summary>
+        /// The compile-time name of the property which stores the wrapped value.
+        /// </summary>
+        public const string PropertyName = nameof(Value);
+
+        /// <summary>
+        /// The actual value represented by this instance.
+        /// </summary>
+        public object Value { get; }
+
+        /// <summary>
+        /// Gets the value indicating whether the option wrapped in this <see cref="IndexableOption{T}"/> is indexed. 
+        /// If true, the wrapped value represents an array of <typeparamref name="T"/>, if not, a single value of <typeparamref name="T"/>.
+        /// </summary>
+        public bool IsIndexed { get; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="IndexableOption{T}"/> which represents a single value.
+        /// </summary>
+        /// <param name="singleValue">The single value this <see cref="IndexableOption{T}"/> represents.</param>
+        public IndexableOption(T singleValue)
+        {
+            if (singleValue == null)
+                throw new ArgumentNullException(nameof(singleValue));
+
+            IsIndexed = false;
+            Value = singleValue;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="IndexableOption{T}"/> which represents an array of values.
+        /// </summary>
+        /// <param name="indexedValues">The array of values this <see cref="IndexableOption{T}"/> represents.</param>
+        public IndexableOption(T[] indexedValues)
+        {
+            if (indexedValues == null)
+                throw new ArgumentNullException(nameof(indexedValues));
+
+            IsIndexed = true;
+            Value = indexedValues;
+        }
+
+        /// <summary>
+        /// Implicitly wraps a single value of <typeparamref name="T"/> to a new instance of <see cref="IndexableOption{T}"/>.
+        /// </summary>
+        /// <param name="singleValue">The single value to wrap</param>
+        public static implicit operator IndexableOption<T>(T singleValue) => new IndexableOption<T>(singleValue);
+
+        /// <summary>
+        /// Implicitly wraps an array of values of <typeparamref name="T"/> to a new instance of <see cref="IndexableOption{T}"/>.
+        /// </summary>
+        /// <param name="indexedValues">The array of values to wrap</param>
+        public static implicit operator IndexableOption<T>(T[] indexedValues) => new IndexableOption<T>(indexedValues);
+
+        public static implicit operator IndexableOption<T>(List<string> v)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Determines whether the specified object instance is considered equal to the current instance.
+        /// </summary>
+        /// <param name="obj">The object to compare with.</param>
+        /// <returns>true if the objects are considered equal; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is IndexableOption<T> option)
+            {
+                return EqualityComparer<object>.Default.Equals(Value, option.Value);
+            }
+            else
+            {
+                return EqualityComparer<object>.Default.Equals(Value, obj);
+            }
+        }
+
+        /// <summary>
+        /// Returns the hash of the underlying object.
+        /// </summary>
+        /// <returns>The hash of the underlying object.</returns>
+        public override int GetHashCode()
+        {
+            return -1937169414 + EqualityComparer<object>.Default.GetHashCode(Value);
+        }
+    }
+}

--- a/ChartJs.Blazor/ChartJS/Common/IndexableOption.cs
+++ b/ChartJs.Blazor/ChartJS/Common/IndexableOption.cs
@@ -111,6 +111,7 @@ namespace ChartJs.Blazor.ChartJS.Common
         /// <returns>true if the objects are considered equal; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
+            // an indexable option cannot store null
             if (obj == null) return false;
 
             if (obj is IndexableOption<T> option)
@@ -131,5 +132,21 @@ namespace ChartJs.Blazor.ChartJS.Common
         {
             return -1937169414 + Value.GetHashCode();
         }
+
+        /// <summary>
+        /// Determines whether two specified <see cref="IndexableOption{T}"/> instances contain the same value.
+        /// </summary>
+        /// <param name="a">The first <see cref="IndexableOption{T}"/> to compare</param>
+        /// <param name="b">The second <see cref="IndexableOption{T}"/> to compare</param>
+        /// <returns>true if the value of a is the same as the value of b; otherwise, false.</returns>
+        public static bool operator ==(IndexableOption<T> a, IndexableOption<T> b) => a.Equals(b);
+
+        /// <summary>
+        /// Determines whether two specified <see cref="IndexableOption{T}"/> instances contain different values.
+        /// </summary>
+        /// <param name="a">The first <see cref="IndexableOption{T}"/> to compare</param>
+        /// <param name="b">The second <see cref="IndexableOption{T}"/> to compare</param>
+        /// <returns>true if the value of a is different from the value of b; otherwise, false.</returns>
+        public static bool operator !=(IndexableOption<T> a, IndexableOption<T> b) => !(a == b);
     }
 }

--- a/ChartJs.Blazor/ChartJS/Common/IndexableOptionConverter.cs
+++ b/ChartJs.Blazor/ChartJS/Common/IndexableOptionConverter.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ChartJs.Blazor.ChartJS.Common
+{
+    internal class IndexableOptionConverter : JsonConverter
+    {
+        public override bool CanRead => false;
+        public override bool CanWrite => true;
+
+        public override bool CanConvert(Type objectType)
+        {
+            if (!objectType.IsGenericType) return false;
+
+            return objectType.GetGenericTypeDefinition() == typeof(IndexableOption<>);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            // this doesn't work because it will apparently use the converter also in here resulting in an endless loop -> StackOverflowException
+            // JObject o = JObject.FromObject(value, serializer);
+            // JProperty prop = o.Property(IndexableOption<object>.PropertyName);
+            // prop.Value.WriteTo(writer);
+
+            // get the value using reflection and write it to the writer
+            object toWrite = value.GetType().GetProperty(IndexableOption<object>.PropertyName).GetValue(value);
+            JToken.FromObject(toWrite).WriteTo(writer);
+        }
+    }
+}

--- a/ChartJs.Blazor/ChartJS/PieChart/PieDataset.cs
+++ b/ChartJs.Blazor/ChartJS/PieChart/PieDataset.cs
@@ -16,11 +16,11 @@ namespace ChartJs.Blazor.ChartJS.PieChart
         public ChartTypes Type { get; } = ChartTypes.Pie;
 
         /// <summary>
-        /// Gets the fill color of the arcs in the dataset.
+        /// Gets or sets the fill color of the arcs in the dataset.
         /// This property should be indexed, otherwise you can't distinguish the different arcs.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> BackgroundColor { get; set; }
+        public IndexableOption<string>? BackgroundColor { get; set; }
 
         // Todo: Make this an enum later?!
         /// <summary>
@@ -30,32 +30,32 @@ namespace ChartJs.Blazor.ChartJS.PieChart
         public string BorderAlign { get; set; } = "center";
 
         /// <summary>
-        /// Gets the border color of the arcs in the dataset.
+        /// Gets or sets the border color of the arcs in the dataset.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> BorderColor { get; set; }
+        public IndexableOption<string>? BorderColor { get; set; }
 
         /// <summary>
-        /// Gets the border width of the arcs in the dataset.
+        /// Gets or sets the border width of the arcs in the dataset.
         /// </summary>
-        public IndexableOption<int> BorderWidth { get; set; }
+        public IndexableOption<int>? BorderWidth { get; set; }
 
         /// <summary>
-        /// Gets the fill colour of the arcs when hovered.
+        /// Gets or sets the fill colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> HoverBackgroundColor { get; set; }
+        public IndexableOption<string>? HoverBackgroundColor { get; set; }
 
         /// <summary>
-        /// Gets the stroke colour of the arcs when hovered.
+        /// Gets or sets the stroke colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> HoverBorderColor { get; set; }
+        public IndexableOption<string>? HoverBorderColor { get; set; }
 
         /// <summary>
-        /// Gets the stroke width of the arcs when hovered.
+        /// Gets or sets the stroke width of the arcs when hovered.
         /// </summary>
-        public IndexableOption<int> HoverBorderWidth { get; set; }
+        public IndexableOption<int>? HoverBorderWidth { get; set; }
 
         /// <summary>
         /// Gets or sets the relative thickness of the dataset.

--- a/ChartJs.Blazor/ChartJS/PieChart/PieDataset.cs
+++ b/ChartJs.Blazor/ChartJS/PieChart/PieDataset.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ChartJs.Blazor.ChartJS.Common;
 using ChartJs.Blazor.ChartJS.Common.Enums;
 using ChartJs.Blazor.Util.Color;
 
@@ -16,9 +17,10 @@ namespace ChartJs.Blazor.ChartJS.PieChart
 
         /// <summary>
         /// Gets the fill color of the arcs in the dataset.
+        /// This property should be indexed, otherwise you can't distinguish the different arcs.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> BackgroundColor { get; } = new List<string>();
+        public IndexableOption<string> BackgroundColor { get; set; }
 
         // Todo: Make this an enum later?!
         /// <summary>
@@ -31,29 +33,29 @@ namespace ChartJs.Blazor.ChartJS.PieChart
         /// Gets the border color of the arcs in the dataset.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> BorderColor { get; } = new List<string>();
+        public IndexableOption<string> BorderColor { get; set; }
 
         /// <summary>
         /// Gets the border width of the arcs in the dataset.
         /// </summary>
-        public List<int> BorderWidth { get; } = new List<int>();
+        public IndexableOption<int> BorderWidth { get; set; }
 
         /// <summary>
         /// Gets the fill colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> HoverBackgroundColor { get; } = new List<string>();
+        public IndexableOption<string> HoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Gets the stroke colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> HoverBorderColor { get; } = new List<string>();
+        public IndexableOption<string> HoverBorderColor { get; set; }
 
         /// <summary>
         /// Gets the stroke width of the arcs when hovered.
         /// </summary>
-        public List<int> HoverBorderWidth { get; } = new List<int>();
+        public IndexableOption<int> HoverBorderWidth { get; set; }
 
         /// <summary>
         /// Gets or sets the relative thickness of the dataset.

--- a/ChartJs.Blazor/ChartJS/PolarAreaChart/Axis/PointLabels.cs
+++ b/ChartJs.Blazor/ChartJS/PolarAreaChart/Axis/PointLabels.cs
@@ -11,10 +11,10 @@ namespace ChartJs.Blazor.ChartJS.PolarAreaChart.Axis
     public class PointLabels
     {
         /// <summary>
-        /// Gets the font color for a point label.
+        /// Gets or sets the font color for a point label.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> FontColor { get; set; }
+        public IndexableOption<string>? FontColor { get; set; }
 
         /// <summary>
         /// Gets or sets the font size in pixels.

--- a/ChartJs.Blazor/ChartJS/PolarAreaChart/Axis/PointLabels.cs
+++ b/ChartJs.Blazor/ChartJS/PolarAreaChart/Axis/PointLabels.cs
@@ -1,4 +1,5 @@
-﻿using ChartJs.Blazor.Util.Color;
+﻿using ChartJs.Blazor.ChartJS.Common;
+using ChartJs.Blazor.Util.Color;
 using System.Collections.Generic;
 
 namespace ChartJs.Blazor.ChartJS.PolarAreaChart.Axis
@@ -13,7 +14,7 @@ namespace ChartJs.Blazor.ChartJS.PolarAreaChart.Axis
         /// Gets the font color for a point label.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> FontColor { get; } = new List<string>();
+        public IndexableOption<string> FontColor { get; set; }
 
         /// <summary>
         /// Gets or sets the font size in pixels.

--- a/ChartJs.Blazor/ChartJS/PolarAreaChart/PolarAreaDataset.cs
+++ b/ChartJs.Blazor/ChartJS/PolarAreaChart/PolarAreaDataset.cs
@@ -1,4 +1,5 @@
-﻿using ChartJs.Blazor.ChartJS.Common.Enums;
+﻿using ChartJs.Blazor.ChartJS.Common;
+using ChartJs.Blazor.ChartJS.Common.Enums;
 using ChartJs.Blazor.Charts;
 using ChartJs.Blazor.Util.Color;
 using System.Collections.Generic;
@@ -19,7 +20,7 @@ namespace ChartJs.Blazor.ChartJS.PolarAreaChart
         /// Gets the fill color of the arcs in the dataset.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> BackgroundColor { get; } = new List<string>();
+        public IndexableOption<string> BackgroundColor { get; set; }
 
         // Todo: Make this an enum later?!
         /// <summary>
@@ -32,29 +33,29 @@ namespace ChartJs.Blazor.ChartJS.PolarAreaChart
         /// Gets the border color of the arcs in the dataset.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> BorderColor { get; } = new List<string>();
+        public IndexableOption<string> BorderColor { get; set; }
 
         /// <summary>
         /// Gets the border width of the arcs in the dataset.
         /// </summary>
-        public List<int> BorderWidth { get; } = new List<int>();
+        public IndexableOption<int> BorderWidth { get; set; }
 
         /// <summary>
         /// Gets the fill colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> HoverBackgroundColor { get; } = new List<string>();
+        public IndexableOption<string> HoverBackgroundColor { get; set; }
 
         /// <summary>
         /// Gets the stroke colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public List<string> HoverBorderColor { get; } = new List<string>();
+        public IndexableOption<string> HoverBorderColor { get; set; }
 
         /// <summary>
         /// Gets the stroke width of the arcs when hovered.
         /// </summary>
-        public List<int> HoverBorderWidth { get; } = new List<int>();
+        public IndexableOption<int> HoverBorderWidth { get; set; }
 
         /// <summary>
         /// Gets the data in the dataset.

--- a/ChartJs.Blazor/ChartJS/PolarAreaChart/PolarAreaDataset.cs
+++ b/ChartJs.Blazor/ChartJS/PolarAreaChart/PolarAreaDataset.cs
@@ -17,10 +17,10 @@ namespace ChartJs.Blazor.ChartJS.PolarAreaChart
         public ChartTypes Type { get; } = ChartTypes.PolarArea;
 
         /// <summary>
-        /// Gets the fill color of the arcs in the dataset.
+        /// Gets or sets the fill color of the arcs in the dataset.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> BackgroundColor { get; set; }
+        public IndexableOption<string>? BackgroundColor { get; set; }
 
         // Todo: Make this an enum later?!
         /// <summary>
@@ -30,32 +30,32 @@ namespace ChartJs.Blazor.ChartJS.PolarAreaChart
         public string BorderAlign { get; set; }
 
         /// <summary>
-        /// Gets the border color of the arcs in the dataset.
+        /// Gets or sets the border color of the arcs in the dataset.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> BorderColor { get; set; }
+        public IndexableOption<string>? BorderColor { get; set; }
 
         /// <summary>
-        /// Gets the border width of the arcs in the dataset.
+        /// Gets or sets the border width of the arcs in the dataset.
         /// </summary>
-        public IndexableOption<int> BorderWidth { get; set; }
+        public IndexableOption<int>? BorderWidth { get; set; }
 
         /// <summary>
-        /// Gets the fill colour of the arcs when hovered.
+        /// Gets or sets the fill colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> HoverBackgroundColor { get; set; }
+        public IndexableOption<string>? HoverBackgroundColor { get; set; }
 
         /// <summary>
-        /// Gets the stroke colour of the arcs when hovered.
+        /// Gets or sets the stroke colour of the arcs when hovered.
         /// <para>See <see cref="ColorUtil"/> for working with colors.</para>
         /// </summary>
-        public IndexableOption<string> HoverBorderColor { get; set; }
+        public IndexableOption<string>? HoverBorderColor { get; set; }
 
         /// <summary>
-        /// Gets the stroke width of the arcs when hovered.
+        /// Gets or sets the stroke width of the arcs when hovered.
         /// </summary>
-        public IndexableOption<int> HoverBorderWidth { get; set; }
+        public IndexableOption<int>? HoverBorderWidth { get; set; }
 
         /// <summary>
         /// Gets the data in the dataset.

--- a/ChartJs.Blazor/ChartJs.Blazor.xml
+++ b/ChartJs.Blazor/ChartJs.Blazor.xml
@@ -637,6 +637,65 @@
             If true, grid lines will be shifted to be between labels. This is set to true for a category scale in a bar chart by default.
             </summary>
         </member>
+        <member name="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1">
+            <summary>
+            Represents a field that can be either a single value or multiple values (array). This is used for typesafe js-interop.
+            </summary>
+            <typeparam name="T">The type of data this <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/> is supposed to hold.</typeparam>
+        </member>
+        <member name="F:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.PropertyName">
+            <summary>
+            The compile-time name of the property which stores the wrapped value.
+            </summary>
+        </member>
+        <member name="P:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.Value">
+            <summary>
+            The actual value represented by this instance.
+            </summary>
+        </member>
+        <member name="P:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.IsIndexed">
+            <summary>
+            Gets the value indicating whether the option wrapped in this <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/> is indexed. 
+            If true, the wrapped value represents an array of <typeparamref name="T"/>, if not, a single value of <typeparamref name="T"/>.
+            </summary>
+        </member>
+        <member name="M:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.#ctor(`0)">
+            <summary>
+            Creates a new instance of <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/> which represents a single value.
+            </summary>
+            <param name="singleValue">The single value this <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/> represents.</param>
+        </member>
+        <member name="M:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.#ctor(`0[])">
+            <summary>
+            Creates a new instance of <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/> which represents an array of values.
+            </summary>
+            <param name="indexedValues">The array of values this <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/> represents.</param>
+        </member>
+        <member name="M:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.op_Implicit(`0)~ChartJs.Blazor.ChartJS.Common.IndexableOption{`0}">
+            <summary>
+            Implicitly wraps a single value of <typeparamref name="T"/> to a new instance of <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/>.
+            </summary>
+            <param name="singleValue">The single value to wrap</param>
+        </member>
+        <member name="M:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.op_Implicit(`0[])~ChartJs.Blazor.ChartJS.Common.IndexableOption{`0}">
+            <summary>
+            Implicitly wraps an array of values of <typeparamref name="T"/> to a new instance of <see cref="T:ChartJs.Blazor.ChartJS.Common.IndexableOption`1"/>.
+            </summary>
+            <param name="indexedValues">The array of values to wrap</param>
+        </member>
+        <member name="M:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.Equals(System.Object)">
+            <summary>
+            Determines whether the specified object instance is considered equal to the current instance.
+            </summary>
+            <param name="obj">The object to compare with.</param>
+            <returns>true if the objects are considered equal; otherwise, false.</returns>
+        </member>
+        <member name="M:ChartJs.Blazor.ChartJS.Common.IndexableOption`1.GetHashCode">
+            <summary>
+            Returns the hash of the underlying object.
+            </summary>
+            <returns>The hash of the underlying object.</returns>
+        </member>
         <member name="T:ChartJs.Blazor.ChartJS.Common.Legends.LegendLabelConfiguration">
             <summary>
             The legend label configuration is nested below the legend configuration
@@ -1813,6 +1872,7 @@
         <member name="P:ChartJs.Blazor.ChartJS.PieChart.PieDataset.BackgroundColor">
             <summary>
             Gets the fill color of the arcs in the dataset.
+            This property should be indexed, otherwise you can't distinguish the different arcs.
             <para>See <see cref="T:ChartJs.Blazor.Util.Color.ColorUtil"/> for working with colors.</para>
             </summary>
         </member>

--- a/WebCore/Pages/DoughnutExample.razor
+++ b/WebCore/Pages/DoughnutExample.razor
@@ -34,14 +34,15 @@
 
         config.Data.Labels.AddRange(new[] { "A", "B", "C", "D" });
 
-        var doughnutSet = new PieDataset();
-
-        doughnutSet.BackgroundColor.AddRange(new List<string> { "#ff6384", "#55ee84", "#4463ff", "#efefef" });
-        doughnutSet.BorderWidth.Add(0);
-        doughnutSet.HoverBackgroundColor.AddRange(new List<string> { "#f06384" });
-        doughnutSet.HoverBorderColor.AddRange(new List<string> { "#f06384" });
-        doughnutSet.HoverBorderWidth.Add(1);
-        doughnutSet.BorderColor.AddRange(new List<string> { "#ffffff", "#ffffff", "#ffffff", "#ffffff" });
+        var doughnutSet = new PieDataset()
+        {
+            BackgroundColor = new[] { "#ff6384", "#55ee84", "#4463ff", "#efefef" },
+            BorderWidth = 0,
+            HoverBackgroundColor = "#f06384",
+            HoverBorderColor = "#f06384",
+            HoverBorderWidth = 1,
+            BorderColor = "#ffffff"
+        };
 
         doughnutSet.Data.AddRange(new List<double> { 4, 5, 6, 7 });
         config.Data.Datasets.Add(doughnutSet);

--- a/WebCore/Pages/PieExample.razor
+++ b/WebCore/Pages/PieExample.razor
@@ -2,6 +2,7 @@
 @using ChartJs.Blazor.Charts
 @using ChartJs.Blazor.ChartJS.PieChart
 @using ChartJs.Blazor.ChartJS.Common.Properties
+@using ChartJs.Blazor.Util.Color
 
 <h1>Pie Chart</h1>
 
@@ -34,14 +35,15 @@
 
         config.Data.Labels.AddRange(new[] { "A", "B", "C", "D" });
 
-        var pieSet = new PieDataset();
-
-        pieSet.BackgroundColor.AddRange(new List<string> { "#ff6384", "#55ee84", "#4463ff", "#efefef" });
-        pieSet.BorderWidth.Add(0);
-        pieSet.HoverBackgroundColor.AddRange(new List<string> { "#f06384" });
-        pieSet.HoverBorderColor.AddRange(new List<string> { "#f06384" });
-        pieSet.HoverBorderWidth.Add(1);
-        pieSet.BorderColor.AddRange(new List<string> { "#ffffff", "#ffffff", "#ffffff", "#ffffff" });
+        var pieSet = new PieDataset()
+        {
+            BackgroundColor = new[] { "#ff6384", "#55ee84", "#4463ff", "#efefef" },
+            BorderWidth = 0,
+            HoverBackgroundColor = "#f06384",
+            HoverBorderColor = "#f06384",
+            HoverBorderWidth = 1,
+            BorderColor = "#ffffff",
+        };
 
         pieSet.Data.AddRange(new List<double> { 4, 5, 6, 7 });
         config.Data.Datasets.Add(pieSet);


### PR DESCRIPTION
Fixes https://github.com/Joelius300/ChartJSBlazor/issues/45

This contains the base implementation for `IndexableOption`. We will need to do the other properties this applies to as well. We should do those on the fly or if requested. It might also be a good idea to create a list of places where this has to be done (new issue).  
Currently I've only changed those which were set to a `List<T>` and only exposed a getter. This _really_ bothered me since you were not able to _not_ index the values and it also made creating the classes (e.g. `PieDataset`) a lot uglier because of the missing setter.  

Both of these concerns are now fixed as you can see in the updated samples.  

Side note: I implemented the newtonsoft converter since we're still depending on it anyway. I will rework this with the other converters once we are able to move away from json.net. The solution for the `System.Text.Json` converter is [here](https://github.com/Joelius300/serialization-tests/blob/master/IndexableOptionTests/Converters/IndexableOptionConverterFactory.cs).