### PR TITLE
Fix function defaults (onClick & generateLabels)

### DIFF
--- a/ChartJs.Blazor/wwwroot/ChartJsInterop.js
+++ b/ChartJs.Blazor/wwwroot/ChartJsInterop.js
@@ -99,16 +99,27 @@ function WireUpGenerateLabelsFunc(config) {
         var generateLabelsFunc = window[generateLabelsNamespaceAndFunc[0]][generateLabelsNamespaceAndFunc[1]];
         if (typeof generateLabels === "function")
             config.options.legend.labels.generateLabels = generateLabelsFunc;
-    // https://github.com/mariusmuntean/ChartJs.Blazor/pull/18
-    //    } else { // fallback to the default
-    //        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
-    //    }
-    //} else { // fallback to the default
-    //    config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
+        // https://github.com/mariusmuntean/ChartJs.Blazor/pull/18
+        //    } else { // fallback to the default
+        //        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
+        //    }
+        //} else { // fallback to the default
+        //    config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
     }
 }
 
 function WireUpOnClick(config) {
+    let getDefaultHandler = function (type) {
+        switch (type) {
+            case "pie":
+                return Chart.defaults.pie.legend.onClick;
+            case "polarArea":
+                return Chart.defaults.polarArea.legend.onClick;
+            default:
+                return Chart.defaults.global.legend.onClick;
+        }
+    }
+
     if (config.options.legend.onClick) {
         // Js function
         if (typeof config.options.legend.onClick === "object" &&
@@ -118,7 +129,7 @@ function WireUpOnClick(config) {
             if (typeof onClickFunc === "function") {
                 config.options.legend.onClick = onClickFunc;
             } else { // fallback to the default
-                config.options.legend.onClick = Chart.defaults.global.legend.onClick;
+                config.options.legend.onClick = getDefaultHandler(config.type);
             }
         }
         // .Net static method
@@ -146,7 +157,7 @@ function WireUpOnClick(config) {
             })();
         }
     } else { // fallback to the default
-        config.options.legend.onClick = Chart.defaults.global.legend.onClick;
+        config.options.legend.onClick = getDefaultHandler(config.type);
     }
 }
 

--- a/ChartJs.Blazor/wwwroot/ChartJsInterop.js
+++ b/ChartJs.Blazor/wwwroot/ChartJsInterop.js
@@ -90,6 +90,7 @@ function WireUpLegendItemFilterFunc(config) {
 
 function WireUpGenerateLabelsFunc(config) {
     let getDefaultFunc = function (type) {
+        // if there are other places we have this, don't use a switch, use [type]
         switch (type) {
             case "pie":
                 return Chart.defaults.pie.legend.labels.generateLabels;
@@ -120,6 +121,7 @@ function WireUpGenerateLabelsFunc(config) {
 
 function WireUpOnClick(config) {
     let getDefaultHandler = function (type) {
+        // if there are other places we have this, don't use a switch, use [type]
         switch (type) {
             case "pie":
                 return Chart.defaults.pie.legend.onClick;

--- a/ChartJs.Blazor/wwwroot/ChartJsInterop.js
+++ b/ChartJs.Blazor/wwwroot/ChartJsInterop.js
@@ -90,15 +90,14 @@ function WireUpLegendItemFilterFunc(config) {
 
 function WireUpGenerateLabelsFunc(config) {
     let getDefaultFunc = function (type) {
-        // if there are other places we have this, don't use a switch, use [type]
-        switch (type) {
-            case "pie":
-                return Chart.defaults.pie.legend.labels.generateLabels;
-            case "polarArea":
-                return Chart.defaults.polarArea.legend.labels.generateLabels;
-            default:
-                return Chart.defaults.global.legend.labels.generateLabels;
+        let defaults = Chart.defaults[type] || Chart.defaults.global;
+        if (defaults.legend &&
+            defaults.legend.labels &&
+            defaults.legend.labels.generateLabels) {
+            return defaults.legend.labels.generateLabels;
         }
+
+        return Chart.defaults.global.legend.labels.generateLabels;
     }
 
     if (config.options.legend.labels === undefined)
@@ -121,15 +120,13 @@ function WireUpGenerateLabelsFunc(config) {
 
 function WireUpOnClick(config) {
     let getDefaultHandler = function (type) {
-        // if there are other places we have this, don't use a switch, use [type]
-        switch (type) {
-            case "pie":
-                return Chart.defaults.pie.legend.onClick;
-            case "polarArea":
-                return Chart.defaults.polarArea.legend.onClick;
-            default:
-                return Chart.defaults.global.legend.onClick;
+        let defaults = Chart.defaults[type] || Chart.defaults.global;
+        if (defaults.legend &&
+            defaults.legend.onClick) {
+            return defaults.legend.onClick;
         }
+
+        return Chart.defaults.global.legend.onClick;
     }
 
     if (config.options.legend.onClick) {

--- a/ChartJs.Blazor/wwwroot/ChartJsInterop.js
+++ b/ChartJs.Blazor/wwwroot/ChartJsInterop.js
@@ -89,6 +89,17 @@ function WireUpLegendItemFilterFunc(config) {
 }
 
 function WireUpGenerateLabelsFunc(config) {
+    let getDefaultFunc = function (type) {
+        switch (type) {
+            case "pie":
+                return Chart.defaults.pie.legend.labels.generateLabels;
+            case "polarArea":
+                return Chart.defaults.polarArea.legend.labels.generateLabels;
+            default:
+                return Chart.defaults.global.legend.labels.generateLabels;
+        }
+    }
+
     if (config.options.legend.labels === undefined)
         config.options.legend.labels = {};
 
@@ -97,14 +108,13 @@ function WireUpGenerateLabelsFunc(config) {
         config.options.legend.labels.generateLabels.includes(".")) {
         var generateLabelsNamespaceAndFunc = config.options.legend.labels.generateLabels.split(".");
         var generateLabelsFunc = window[generateLabelsNamespaceAndFunc[0]][generateLabelsNamespaceAndFunc[1]];
-        if (typeof generateLabels === "function")
+        if (typeof generateLabels === "function") {
             config.options.legend.labels.generateLabels = generateLabelsFunc;
-        // https://github.com/mariusmuntean/ChartJs.Blazor/pull/18
-        //    } else { // fallback to the default
-        //        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
-        //    }
-        //} else { // fallback to the default
-        //    config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
+        } else { // fallback to the default
+            config.options.legend.labels.generateLabels = getDefaultFunc(config.type);
+        }
+    } else { // fallback to the default
+        config.options.legend.labels.generateLabels = getDefaultFunc(config.type);
     }
 }
 

--- a/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
+++ b/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
@@ -99,16 +99,27 @@ function WireUpGenerateLabelsFunc(config) {
         var generateLabelsFunc = window[generateLabelsNamespaceAndFunc[0]][generateLabelsNamespaceAndFunc[1]];
         if (typeof generateLabels === "function")
             config.options.legend.labels.generateLabels = generateLabelsFunc;
-    // https://github.com/mariusmuntean/ChartJs.Blazor/pull/18
-    //    } else { // fallback to the default
-    //        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
-    //    }
-    //} else { // fallback to the default
-    //    config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
+        // https://github.com/mariusmuntean/ChartJs.Blazor/pull/18
+        //    } else { // fallback to the default
+        //        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
+        //    }
+        //} else { // fallback to the default
+        //    config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
     }
 }
 
 function WireUpOnClick(config) {
+    let getDefaultHandler = function (type) {
+        switch (type) {
+            case "pie":
+                return Chart.defaults.pie.legend.onClick;
+            case "polarArea":
+                return Chart.defaults.polarArea.legend.onClick;
+            default:
+                return Chart.defaults.global.legend.onClick;
+        }
+    }
+
     if (config.options.legend.onClick) {
         // Js function
         if (typeof config.options.legend.onClick === "object" &&
@@ -118,7 +129,7 @@ function WireUpOnClick(config) {
             if (typeof onClickFunc === "function") {
                 config.options.legend.onClick = onClickFunc;
             } else { // fallback to the default
-                config.options.legend.onClick = Chart.defaults.global.legend.onClick;
+                config.options.legend.onClick = getDefaultHandler(config.type);
             }
         }
         // .Net static method
@@ -146,7 +157,7 @@ function WireUpOnClick(config) {
             })();
         }
     } else { // fallback to the default
-        config.options.legend.onClick = Chart.defaults.global.legend.onClick;
+        config.options.legend.onClick = getDefaultHandler(config.type);
     }
 }
 

--- a/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
+++ b/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
@@ -90,6 +90,7 @@ function WireUpLegendItemFilterFunc(config) {
 
 function WireUpGenerateLabelsFunc(config) {
     let getDefaultFunc = function (type) {
+        // if there are other places we have this, don't use a switch, use [type]
         switch (type) {
             case "pie":
                 return Chart.defaults.pie.legend.labels.generateLabels;
@@ -120,6 +121,7 @@ function WireUpGenerateLabelsFunc(config) {
 
 function WireUpOnClick(config) {
     let getDefaultHandler = function (type) {
+        // if there are other places we have this, don't use a switch, use [type]
         switch (type) {
             case "pie":
                 return Chart.defaults.pie.legend.onClick;

--- a/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
+++ b/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
@@ -90,15 +90,14 @@ function WireUpLegendItemFilterFunc(config) {
 
 function WireUpGenerateLabelsFunc(config) {
     let getDefaultFunc = function (type) {
-        // if there are other places we have this, don't use a switch, use [type]
-        switch (type) {
-            case "pie":
-                return Chart.defaults.pie.legend.labels.generateLabels;
-            case "polarArea":
-                return Chart.defaults.polarArea.legend.labels.generateLabels;
-            default:
-                return Chart.defaults.global.legend.labels.generateLabels;
+        let defaults = Chart.defaults[type] || Chart.defaults.global;
+        if (defaults.legend &&
+            defaults.legend.labels &&
+            defaults.legend.labels.generateLabels) {
+            return defaults.legend.labels.generateLabels;
         }
+
+        return Chart.defaults.global.legend.labels.generateLabels;
     }
 
     if (config.options.legend.labels === undefined)
@@ -121,15 +120,13 @@ function WireUpGenerateLabelsFunc(config) {
 
 function WireUpOnClick(config) {
     let getDefaultHandler = function (type) {
-        // if there are other places we have this, don't use a switch, use [type]
-        switch (type) {
-            case "pie":
-                return Chart.defaults.pie.legend.onClick;
-            case "polarArea":
-                return Chart.defaults.polarArea.legend.onClick;
-            default:
-                return Chart.defaults.global.legend.onClick;
+        let defaults = Chart.defaults[type] || Chart.defaults.global;
+        if (defaults.legend &&
+            defaults.legend.onClick) {
+            return defaults.legend.onClick;
         }
+
+        return Chart.defaults.global.legend.onClick;
     }
 
     if (config.options.legend.onClick) {

--- a/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
+++ b/WebCore/wwwroot/ChartJs.Blazor/ChartJsInterop.js
@@ -89,6 +89,17 @@ function WireUpLegendItemFilterFunc(config) {
 }
 
 function WireUpGenerateLabelsFunc(config) {
+    let getDefaultFunc = function (type) {
+        switch (type) {
+            case "pie":
+                return Chart.defaults.pie.legend.labels.generateLabels;
+            case "polarArea":
+                return Chart.defaults.polarArea.legend.labels.generateLabels;
+            default:
+                return Chart.defaults.global.legend.labels.generateLabels;
+        }
+    }
+
     if (config.options.legend.labels === undefined)
         config.options.legend.labels = {};
 
@@ -97,14 +108,13 @@ function WireUpGenerateLabelsFunc(config) {
         config.options.legend.labels.generateLabels.includes(".")) {
         var generateLabelsNamespaceAndFunc = config.options.legend.labels.generateLabels.split(".");
         var generateLabelsFunc = window[generateLabelsNamespaceAndFunc[0]][generateLabelsNamespaceAndFunc[1]];
-        if (typeof generateLabels === "function")
+        if (typeof generateLabels === "function") {
             config.options.legend.labels.generateLabels = generateLabelsFunc;
-        // https://github.com/mariusmuntean/ChartJs.Blazor/pull/18
-        //    } else { // fallback to the default
-        //        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
-        //    }
-        //} else { // fallback to the default
-        //    config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
+        } else { // fallback to the default
+            config.options.legend.labels.generateLabels = getDefaultFunc(config.type);
+        }
+    } else { // fallback to the default
+        config.options.legend.labels.generateLabels = getDefaultFunc(config.type);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/Joelius300/ChartJSBlazor/issues/65

Use a function to determine what the default onClick handler should be. It tries to find a specific one for the chart-type and falls back to the global one if it doesn't. Same goes for the generateLabels function.

The updated js-file has been copied to the sample project as well since it's still linked statically at the moment.