### PR TITLE
Make CanvasId readonly

### DIFF
--- a/ChartJs.Blazor/ChartJS/Common/ConfigBase.cs
+++ b/ChartJs.Blazor/ChartJS/Common/ConfigBase.cs
@@ -1,5 +1,6 @@
 using ChartJs.Blazor.ChartJS.Common.Enums;
 using Newtonsoft.Json;
+using System;
 
 namespace ChartJs.Blazor.ChartJS.Common
 {
@@ -26,7 +27,7 @@ namespace ChartJs.Blazor.ChartJS.Common
         /// <summary>
         /// The id for the html canvas element associated with this chart
         /// </summary>
-        public string CanvasId { get; set; }        
+        public string CanvasId { get; } = Guid.NewGuid().ToString();
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ The example covers a few static options, how to use a simple point-dataset and h
     {
         lineConfig = new LineConfig
         {
-            CanvasId = "mySimpleLineChart",
             Options = new LineOptions
             {
                 Responsive = true,

--- a/WebCore/Pages/DoughnutExample.razor
+++ b/WebCore/Pages/DoughnutExample.razor
@@ -15,7 +15,6 @@
     {
         config = new PieConfig
         {
-            CanvasId = "myFirstDoughnutChart",
             Options = new PieOptions(true)
             {
                 Title = new OptionsTitle

--- a/WebCore/Pages/LineLinearExample.razor
+++ b/WebCore/Pages/LineLinearExample.razor
@@ -29,7 +29,6 @@
     {
         lineConfig = new LineConfig
         {
-            CanvasId = "myFirstLineChart",
             Options = new LineOptions
             {
                 Responsive = true,

--- a/WebCore/Pages/LineLogarithmicExample.razor
+++ b/WebCore/Pages/LineLogarithmicExample.razor
@@ -23,7 +23,6 @@
     {
         lineConfig = new LineConfig
         {
-            CanvasId = "myFirstLineChart",
             Options = new LineOptions
             {
                 Responsive = true,

--- a/WebCore/Pages/LineTimeExample.razor
+++ b/WebCore/Pages/LineTimeExample.razor
@@ -41,7 +41,6 @@
     {
         lineConfig = new LineConfig
         {
-            CanvasId = "timeChartExample",
             Options = new LineOptions
             {
                 Responsive = true,

--- a/WebCore/Pages/PieExample.razor
+++ b/WebCore/Pages/PieExample.razor
@@ -16,7 +16,6 @@
     {
         config = new PieConfig
         {
-            CanvasId = "myFirstPieChart",
             Options = new PieOptions
             {
                 Title = new OptionsTitle

--- a/WebCore/Pages/SimpleLineLinearExample.razor
+++ b/WebCore/Pages/SimpleLineLinearExample.razor
@@ -26,7 +26,6 @@
     {
         lineConfig = new LineConfig
         {
-            CanvasId = "mySimpleLineChart",
             Options = new LineOptions
             {
                 Responsive = true,


### PR DESCRIPTION
Fixes https://github.com/Joelius300/ChartJSBlazor/issues/77

The CanvasId does not need to have a setter. It will always use a new GUID-string which makes collisions _very_ rare and it takes away the responsibility of a user having to decide on unique ids which they don't have another use for 90% of the time.